### PR TITLE
PythConnection wrapper for easy subscription to pyth price data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # @pythnetwork/client
 
-## A library for parsing on-chain Pyth oracle data
+## A library for reading on-chain Pyth oracle data
 
 [Pyth](https://pyth.network/) is building a way to deliver a decentralized, cross-chain market of verifiable data from high-quality nodes to any smart contract, anywhere.
 
-This library consumes on-chain Pyth `accountInfo.data` from [@solana/web3.js](https://www.npmjs.com/package/@solana/web3.js) and returns JavaScript-friendly objects.
+This library reads on-chain Pyth data from [@solana/web3.js](https://www.npmjs.com/package/@solana/web3.js) and returns JavaScript-friendly objects.
 
 See our [examples repo](https://github.com/pyth-network/pyth-examples) for real-world usage examples.
 
@@ -24,24 +24,25 @@ $ yarn add @pythnetwork/client
 
 ## Example Usage
 
+This library provides a subscription model for consuming all price updates:
+
 ```javascript
 import { Connection, PublicKey } from '@solana/web3.js'
 import { parseMappingData, parsePriceData, parseProductData } from '@pythnetwork/client'
+import { getPythProgramKeyForCluster } from '@pythnetwork/client'
 
 const connection = new Connection(SOLANA_CLUSTER_URL)
-const publicKey = new PublicKey(ORACLE_MAPPING_PUBLIC_KEY)
+const pythPublicKey = getPythProgramKeyForCluster(CLUSTER)
 
-connection.getAccountInfo(publicKey).then((accountInfo) => {
-  const { productAccountKeys } = parseMappingData(accountInfo.data)
-  connection.getAccountInfo(productAccountKeys[productAccountKeys.length - 1]).then((accountInfo) => {
-    const { product, priceAccountKey } = parseProductData(accountInfo.data)
-    connection.getAccountInfo(priceAccountKey).then((accountInfo) => {
-      const { price, confidence } = parsePriceData(accountInfo.data)
-      console.log(`${product.symbol}: $${price} \xB1$${confidence}`)
-      // SRM/USD: $8.68725 ±$0.0131
-    })
-  })
+const pythConnection = new PythConnection(connection, pythPublicKey) 
+pythConnection.onPriceChange((product, price) => {
+  // sample output:
+  // SRM/USD: $8.68725 ±$0.0131
+  console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence}`)
 })
+
+pythConnection.start()
 ```
 
-To get streaming price updates, you may want to use `connection.onAccountChange`
+You may also register to specific account updates using `connection.onAccountChange` in the solana web3 API, then
+use the methods in `index.ts` to parse the on-chain data structures into Javascript-friendly objects.

--- a/README.md
+++ b/README.md
@@ -24,25 +24,27 @@ $ yarn add @pythnetwork/client
 
 ## Example Usage
 
-This library provides a subscription model for consuming all price updates:
+This library provides a subscription model for consuming price updates:
 
 ```javascript
-import { Connection, PublicKey } from '@solana/web3.js'
-import { parseMappingData, parsePriceData, parseProductData } from '@pythnetwork/client'
-import { getPythProgramKeyForCluster } from '@pythnetwork/client'
-
-const connection = new Connection(SOLANA_CLUSTER_URL)
-const pythPublicKey = getPythProgramKeyForCluster(CLUSTER)
-
-const pythConnection = new PythConnection(connection, pythPublicKey) 
+const pythConnection = new PythConnection(solanaWeb3Connection, getPythProgramKeyForCluster(solanaClusterName))
 pythConnection.onPriceChange((product, price) => {
   // sample output:
   // SRM/USD: $8.68725 ±$0.0131
   console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence}`)
 })
 
+// Start listening for price change events.
 pythConnection.start()
 ```
+
+The `onPriceChange` callback will be invoked every time a Pyth price gets updated.
+This callback gets two arguments:
+* `price` contains the official Pyth price and confidence, along with the component prices that were combined to produce this result.
+* `product` contains metadata about the price feed, such as the symbol (e.g., "BTC/USD") and the number of decimal points.
+
+See `src/example_usage.ts` for a runnable example of the above usage.
+You can run this example with `npm run example`.
 
 You may also register to specific account updates using `connection.onAccountChange` in the solana web3 API, then
 use the methods in `index.ts` to parse the on-chain data structures into Javascript-friendly objects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/web3.js": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepublishOnly": "npm test && npm run lint",
     "preversion": "npm run lint",
     "version": "npm run format && git add -A src",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "example": "npm run build && node lib/example_usage.js"
   },
   "keywords": [
     "pyth",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.2.0",
-  "description": "Pyth price oracle data structures",
+  "version": "2.3.0",
+  "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,0 +1,13 @@
+import {Cluster, PublicKey} from '@solana/web3.js'
+
+/** Mapping from solana clusters to the public key of the pyth program. */
+const clusterToPythProgramKey: Record<Cluster, string> = {
+  'mainnet-beta': 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH',
+  'devnet': 'gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s',
+  'testnet': '8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz',
+}
+
+/** Gets the public key of the Pyth program running on the given cluster. */
+export function getPythProgramKeyForCluster(cluster: Cluster): PublicKey {
+  return new PublicKey(clusterToPythProgramKey[cluster]);
+}

--- a/src/example_usage.ts
+++ b/src/example_usage.ts
@@ -1,0 +1,17 @@
+import {Cluster, clusterApiUrl, Connection, PublicKey} from '@solana/web3.js'
+import { PythConnection } from './PythConnection'
+import { getPythProgramKeyForCluster } from './cluster'
+
+const SOLANA_CLUSTER_NAME: Cluster = 'devnet'
+const connection = new Connection(clusterApiUrl(SOLANA_CLUSTER_NAME))
+const pythPublicKey = getPythProgramKeyForCluster(SOLANA_CLUSTER_NAME)
+
+const pythConnection = new PythConnection(connection, pythPublicKey)
+pythConnection.onPriceChange((product, price) => {
+  // sample output:
+  // SRM/USD: $8.68725 ±$0.0131
+  console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence}`)
+})
+
+console.log("Reading from Pyth price feed...")
+pythConnection.start()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { PublicKey } from '@solana/web3.js'
 import { Buffer } from 'buffer'
 import { readBigInt64LE, readBigUInt64LE } from './readBig'
 
+/** Constants. This section must be kept in sync with the on-chain program. */
+
 export const Magic = 0xa1b2c3d4
 export const Version2 = 2
 export const Version = Version2
@@ -9,6 +11,10 @@ export const PriceStatus = ['Unknown', 'Trading', 'Halted', 'Auction']
 export const CorpAction = ['NoCorpAct']
 export const PriceType = ['Unknown', 'Price']
 export const DeriveType = ['Unknown', 'TWAP', 'Volatility']
+export const AccountType = ['Mapping', 'Product', 'Price', 'Test']
+
+/** Number of slots that can pass before a publisher's price is no longer included in the aggregate. */
+export const MAX_SLOT_DIFFERENCE = 25
 
 const empty32Buffer = Buffer.alloc(32)
 const PKorNull = (data: Buffer) => (data.equals(empty32Buffer) ? null : new PublicKey(data))
@@ -84,6 +90,27 @@ export interface PriceData extends Base, Price {
   drv3Component: bigint
   drv3: number
   priceComponents: PriceComponent[]
+}
+
+/** Parse data as a generic Pyth account. Use this method if you don't know the account type. */
+export function parseBaseData(data: Buffer): Base | undefined {
+  // data is too short to have the magic number.
+  if (data.byteLength < 4) {
+    return undefined
+  }
+
+  const magic = data.readUInt32LE(0)
+  if (magic == Magic) {
+    // program version
+    const version = data.readUInt32LE(4)
+    // account type
+    const type = data.readUInt32LE(8)
+    // account used size
+    const size = data.readUInt32LE(12)
+    return { magic, version, type, size }
+  } else {
+    return undefined
+  }
 }
 
 export const parseMappingData = (data: Buffer): MappingData => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const PriceStatus = ['Unknown', 'Trading', 'Halted', 'Auction']
 export const CorpAction = ['NoCorpAct']
 export const PriceType = ['Unknown', 'Price']
 export const DeriveType = ['Unknown', 'TWAP', 'Volatility']
-export const AccountType = ['Mapping', 'Product', 'Price', 'Test']
+export const AccountType = ['Unknown', 'Mapping', 'Product', 'Price', 'Test']
 
 /** Number of slots that can pass before a publisher's price is no longer included in the aggregate. */
 export const MAX_SLOT_DIFFERENCE = 25


### PR DESCRIPTION
I had to write the subscription logic in a couple different places, so i decided to package it up nicely. This provides an interface that takes the solana connection and lets you register callbacks on (product, price). 