### PR TITLE
[easy] Improve error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 2.5.1
+
+### Changed
+
+Improved error message when passing an invalid cluster name to `pythProgramKeyForCluster`
+
 ### 2.5.0
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.4.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.4.0",
+      "version": "2.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/web3.js": "^1.30.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -1,11 +1,17 @@
-import {Connection, PublicKey, clusterApiUrl, Cluster, Commitment, AccountInfo, Account} from '@solana/web3.js'
+import { Connection, PublicKey, clusterApiUrl, Cluster, Commitment, AccountInfo, Account } from '@solana/web3.js'
 import {
-  Base, Magic,
+  Base,
+  Magic,
   parseMappingData,
   parseBaseData,
   parsePriceData,
-  parseProductData, Price, PriceData, Product, ProductData,
-  Version, AccountType,
+  parseProductData,
+  Price,
+  PriceData,
+  Product,
+  ProductData,
+  Version,
+  AccountType,
 } from './index'
 
 const ONES = '11111111111111111111111111111111'
@@ -31,7 +37,7 @@ export class PythConnection {
   callbacks: PythPriceCallback[] = []
 
   private handleProductAccount(key: PublicKey, account: AccountInfo<Buffer>) {
-    const {priceAccountKey, type, product} = parseProductData(account.data)
+    const { priceAccountKey, type, product } = parseProductData(account.data)
     this.productAccountKeyToProduct[key.toString()] = product
     if (priceAccountKey.toString() !== ONES) {
       this.priceAccountKeyToProductAccountKey[priceAccountKey.toString()] = key.toString()
@@ -43,7 +49,9 @@ export class PythConnection {
     if (product === undefined) {
       // This shouldn't happen since we're subscribed to all of the program's accounts,
       // but let's be good defensive programmers.
-      throw new Error('Got a price update for an unknown product. This is a bug in the library, please report it to the developers.')
+      throw new Error(
+        'Got a price update for an unknown product. This is a bug in the library, please report it to the developers.',
+      )
     }
 
     const priceData = parsePriceData(account.data)
@@ -59,17 +67,17 @@ export class PythConnection {
       switch (AccountType[base.type]) {
         case 'Mapping':
           // We can skip these because we're going to get every account owned by this program anyway.
-          break;
+          break
         case 'Product':
           this.handleProductAccount(key, account)
-          break;
+          break
         case 'Price':
           if (!productOnly) {
             this.handlePriceAccount(key, account)
           }
-          break;
+          break
         case 'Test':
-          break;
+          break
         default:
           throw new Error(`Unknown account type: ${base.type}. Try upgrading pyth-client.`)
       }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -9,5 +9,9 @@ const clusterToPythProgramKey: Record<Cluster, string> = {
 
 /** Gets the public key of the Pyth program running on the given cluster. */
 export function getPythProgramKeyForCluster(cluster: Cluster): PublicKey {
-  return new PublicKey(clusterToPythProgramKey[cluster]);
+  if (clusterToPythProgramKey[cluster] !== undefined) {
+    return new PublicKey(clusterToPythProgramKey[cluster]);
+  } else {
+    throw new Error(`Invalid Solana cluster name: ${cluster}. Valid options are: ${JSON.stringify(Object.keys(clusterToPythProgramKey))}`)
+  }
 }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,17 +1,21 @@
-import {Cluster, PublicKey} from '@solana/web3.js'
+import { Cluster, PublicKey } from '@solana/web3.js'
 
 /** Mapping from solana clusters to the public key of the pyth program. */
 const clusterToPythProgramKey: Record<Cluster, string> = {
   'mainnet-beta': 'FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH',
-  'devnet': 'gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s',
-  'testnet': '8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz',
+  devnet: 'gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s',
+  testnet: '8tfDNiaEyrV6Q1U4DEXrEigs9DoDtkugzFbybENEbCDz',
 }
 
 /** Gets the public key of the Pyth program running on the given cluster. */
 export function getPythProgramKeyForCluster(cluster: Cluster): PublicKey {
   if (clusterToPythProgramKey[cluster] !== undefined) {
-    return new PublicKey(clusterToPythProgramKey[cluster]);
+    return new PublicKey(clusterToPythProgramKey[cluster])
   } else {
-    throw new Error(`Invalid Solana cluster name: ${cluster}. Valid options are: ${JSON.stringify(Object.keys(clusterToPythProgramKey))}`)
+    throw new Error(
+      `Invalid Solana cluster name: ${cluster}. Valid options are: ${JSON.stringify(
+        Object.keys(clusterToPythProgramKey),
+      )}`,
+    )
   }
 }

--- a/src/example_usage.ts
+++ b/src/example_usage.ts
@@ -1,4 +1,4 @@
-import {Cluster, clusterApiUrl, Connection, PublicKey} from '@solana/web3.js'
+import { Cluster, clusterApiUrl, Connection, PublicKey } from '@solana/web3.js'
 import { PythConnection } from './PythConnection'
 import { getPythProgramKeyForCluster } from './cluster'
 
@@ -20,5 +20,5 @@ pythConnection.onPriceChange((product, price) => {
 })
 
 // tslint:disable-next-line:no-console
-console.log("Reading from Pyth price feed...")
+console.log('Reading from Pyth price feed...')
 pythConnection.start()

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export interface PriceData extends Base {
   drv5Component: bigint
   drv5: number
   priceComponents: PriceComponent[]
-  aggregate: Price,
+  aggregate: Price
   // The current price and confidence. The typical use of this interface is to consume these two fields.
   // If undefined, Pyth does not currently have price information for this product. This condition can
   // happen for various reasons (e.g., US equity market is closed, or insufficient publishers), and your
@@ -100,7 +100,7 @@ export interface PriceData extends Base {
   // aggregate.price) may be defined even if this is undefined; you most likely should not use those fields,
   // as their value can be arbitrary when this is undefined.
   price: number | undefined
-  confidence: number | undefined,
+  confidence: number | undefined
 }
 
 /** Parse data as a generic Pyth account. Use this method if you don't know the account type. */
@@ -332,9 +332,9 @@ export const parsePriceData = (data: Buffer): PriceData => {
     aggregate,
     priceComponents,
     price,
-    confidence
+    confidence,
   }
 }
 
-export { PythConnection } from './PythConnection';
-export { getPythProgramKeyForCluster } from './cluster';
+export { PythConnection } from './PythConnection'
+export { getPythProgramKeyForCluster } from './cluster'


### PR DESCRIPTION
Someone ran into an error with the client that was caused by them passing "mainnet" instead of "mainnet-beta" as a solana cluster name. Improve the error message so that I don't have to debug this problem for users in the future.

Sorry for the unrelated changes in here -- it looks like the linter fires when you run `npm version` and it made some changes on its own. I'll call out the only thing i changed in a comment.