### PR TITLE
React-native bigint64 deserialization problem -  refactoring/bigint64le

### DIFF
--- a/src/readBig.ts
+++ b/src/readBig.ts
@@ -1,5 +1,3 @@
-import { Buffer } from 'buffer'
-
 // https://github.com/nodejs/node/blob/v14.17.0/lib/internal/errors.js#L758
 const ERR_BUFFER_OUT_OF_BOUNDS = () => new Error('Attempt to access memory outside buffer bounds')
 
@@ -28,30 +26,12 @@ function boundsError(value: number, length: number) {
   throw ERR_OUT_OF_RANGE('offset', `>= 0 and <= ${length}`, value)
 }
 
-// https://github.com/nodejs/node/blob/v14.17.0/lib/internal/buffer.js#L129-L145
+// This function works with react-native >= 0.66.1
 export function readBigInt64LE(buffer: Buffer, offset = 0): bigint {
-  validateNumber(offset, 'offset')
-  const first = buffer[offset]
-  const last = buffer[offset + 7]
-  if (first === undefined || last === undefined) boundsError(offset, buffer.length - 8)
-  // tslint:disable-next-line:no-bitwise
-  const val = buffer[offset + 4] + buffer[offset + 5] * 2 ** 8 + buffer[offset + 6] * 2 ** 16 + (last << 24) // Overflow
-  return (
-    (BigInt(val) << BigInt(32)) + // tslint:disable-line:no-bitwise
-    BigInt(first + buffer[++offset] * 2 ** 8 + buffer[++offset] * 2 ** 16 + buffer[++offset] * 2 ** 24)
-  )
+  return BigInt(buffer.readIntLE(offset, 8))
 }
 
-// https://github.com/nodejs/node/blob/v14.17.0/lib/internal/buffer.js#L89-L107
+// This function works with react-native >= 0.66.1
 export function readBigUInt64LE(buffer: Buffer, offset = 0): bigint {
-  validateNumber(offset, 'offset')
-  const first = buffer[offset]
-  const last = buffer[offset + 7]
-  if (first === undefined || last === undefined) boundsError(offset, buffer.length - 8)
-
-  const lo = first + buffer[++offset] * 2 ** 8 + buffer[++offset] * 2 ** 16 + buffer[++offset] * 2 ** 24
-
-  const hi = buffer[++offset] + buffer[++offset] * 2 ** 8 + buffer[++offset] * 2 ** 16 + last * 2 ** 24
-
-  return BigInt(lo) + (BigInt(hi) << BigInt(32)) // tslint:disable-line:no-bitwise
+  return BigInt(buffer.readUIntLE(offset, 8))
 }

--- a/src/readBig.ts
+++ b/src/readBig.ts
@@ -28,10 +28,10 @@ function boundsError(value: number, length: number) {
 
 // This function works with react-native >= 0.66.1
 export function readBigInt64LE(buffer: Buffer, offset = 0): bigint {
-  return BigInt(buffer.readIntLE(offset, 8))
+  return BigInt(buffer.readIntLE(offset, 6))
 }
 
 // This function works with react-native >= 0.66.1
 export function readBigUInt64LE(buffer: Buffer, offset = 0): bigint {
-  return BigInt(buffer.readUIntLE(offset, 8))
+  return BigInt(buffer.readUIntLE(offset, 6))
 }


### PR DESCRIPTION
I think react-native can't deserialize prices correctly on all devices.

The price is deserialized to its BigInt32 Little Endian value instead of BigInt64 Little endian value.

I wrote a new code to test this problem.

Example on testnet:
* price public key:  7VJsBtJzgTftYzEeooSDYyjKXvYRWJHdwvbwfBvTg9K
* product public key:  GcnU8V2WKq5QXLhJwBQdt2ankU6GRGh6b1bLCxdykWnP
* price buffer:  b813fdb904000000341a320c00000000010000000000000056da4b0600000000
* correct value from new code:  20300239800
* incorrect value from current code: 3120370620

Test deserialization (only for unsigned): https://asecuritysite.com/encryption/numbers01

Info from my package.json:
    "@babel/core": "^7.12.9"
    "@babel/runtime": "^7.12.5"
    "@pythnetwork/client": "^2.5.1"
    "react": "17.0.2"
    "react-native": "0.66.1"
    "buffer": "^6.0.3"
    "typescript": "^4.3.2"
     [...]
    "resolutions": {
      "@types/react": "^17"
    }

My node version is: v16.13.0

I have a shim configuration to enable bigint support in react-native environment:
    // https://github.com/facebook/react-native/issues/28492#issuecomment-824698934
    if (typeof BigInt === 'undefined') global.BigInt = require('big-integer')
