### PR TITLE
Update unit tests for symbology

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.5.1",
+  "version": "2.5.3",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/__tests__/Product.ETH.test.ts
+++ b/src/__tests__/Product.ETH.test.ts
@@ -15,7 +15,7 @@ test('Product', (done) => {
         console.log(product)
         expect(product.magic).toBe(Magic)
         expect(product.version).toBe(Version)
-        expect(product.product.symbol).toBe('ETH/USD')
+        expect(product.product.symbol).toBe('Crypto.ETH/USD')
         done()
       } else {
         done('No product accountInfo')

--- a/src/__tests__/PythNetworkRestClient-test.ts
+++ b/src/__tests__/PythNetworkRestClient-test.ts
@@ -15,7 +15,7 @@ test('PythHttpClientCall', done => {
           console.log("product symbols: ", result.symbols);
 
           // Find a product with symbol "SOL/USD"
-          const products = result.products.filter(p => p.symbol === "SOL/USD");
+          const products = result.products.filter(p => p.symbol === "Crypto.SOL/USD");
           expect(products.length).toBeGreaterThan(0);
 
           // Find product prices


### PR DESCRIPTION
We renamed some of the symbols, and the unit tests depend on the on-chain symbol names :( 