### PR TITLE
remove unused 'assert' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.30.2",
-    "assert": "^2.0.0",
     "buffer": "^6.0.1"
   }
 }


### PR DESCRIPTION
It's not used anywhere in the `src` or the generated `lib` dirs.

Moreover, `assert` is a huge module that implements Node.js-compatible `assert` API and depends on `util`.

If a simple assertion library is needed in the future, it's better to use e.g. [minimalistic-assert](https://npmjs.com/minimalistic-assert) module for code that is going to be potentially run in browsers to minimize the bundle.

