### PR TITLE
Support price tracking for a given set of price account keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,11 +54,13 @@ export interface MappingData extends Base {
   productAccountKeys: PublicKey[]
 }
 
-export interface Product {
+export type Product = {
   symbol: string
   asset_type: string
   quote_currency: string
   tenor: string
+  price_account: PublicKey
+} & {
   [index: string]: string
 }
 
@@ -195,6 +197,7 @@ export const parseProductData = (data: Buffer): ProductData => {
   const priceAccountBytes = data.slice(16, 48)
   const priceAccountKey = new PublicKey(priceAccountBytes)
   const product = {} as Product
+  product.price_account = priceAccountKey
   let idx = 48
   while (idx < size) {
     const keyLength = data[idx]


### PR DESCRIPTION
It is difficult to use `@pythnetwork/client` to track prices for a given set of price account keys.

PythHttpClient doesn't support this use case at all.

To do this using a PythConnection, you need to start the PythConnection and then create a mapping from product account key to price account key from the PythConnection's priceAccountKeyToProductAccountKey.

This change adds support for this use case by adding the price account key to the `Product` interface.

This is technically a breaking change, but I don't expect it to impact any consumer. It is breaking because TypeScript will now complain if you try to create a `Product` as follows:
```ts
const p: Product = {
  symbol: "xyz",
  asset_type: "abc",
  quote_currency: "usd",
  tenor: "blah",
  price_account: new PublicKey("..."),
}
```
```
Type '{ symbol: string; asset_type: string; quote_currency: string; tenor: string; price_account: PublicKey; }' is not assignable to type 'Product'.
  Type '{ symbol: string; asset_type: string; quote_currency: string; tenor: string; price_account: PublicKey; }' is not assignable to type '{ [index: string]: string; }'.
    Property 'price_account' is incompatible with index signature.
      Type 'PublicKey' is not assignable to type 'string'.
```
I don't expect that any consumer of this library is doing anything like this because
1) the `Product` interface is already broken - it includes tenor, which is only defined on FX and metal products, and
2) this is a data consumption library - there should be no need for a consumer to create a `Product` from scratch.

I think a better fix would be to hand `ProductData` instead of `Product` to consumers, but this would break for all consumers.