### PR TITLE
Support price tracking for a given set of price account keys

### DIFF
--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -22,7 +22,7 @@ const ONES = '11111111111111111111111111111111'
  * Type of callback invoked whenever a pyth price account changes. The callback additionally
  * gets access product, which contains the metadata for this price account (e.g., that the symbol is "BTC/USD")
  */
-export type PythPriceCallback = (product: Product, price: PriceData) => void
+export type PythPriceCallback = (product: Product, price: PriceData, priceAccountKey: PublicKey) => void
 
 /**
  * Reads Pyth price data from a solana web3 connection. This class uses a callback-driven model,
@@ -59,7 +59,7 @@ export class PythConnection {
     const priceData = parsePriceData(account.data, slot)
 
     for (const callback of this.callbacks) {
-      callback(product, priceData)
+      callback(product, priceData, key)
     }
   }
 


### PR DESCRIPTION
Alternative to #25. The change to PythHttpClient is not breaking. I don't think the change to PythConnection is breaking, but let me know if I am wrong.

I still think a better fix would be to hand `ProductData` instead of `Product` to consumers, but this is the best I could do without introducing breaking changes.