### PR TITLE
Support price tracking for a given set of price account keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export interface Product {
   asset_type: string
   quote_currency: string
   tenor: string
+  price_account: string
   [index: string]: string
 }
 
@@ -195,6 +196,7 @@ export const parseProductData = (data: Buffer): ProductData => {
   const priceAccountBytes = data.slice(16, 48)
   const priceAccountKey = new PublicKey(priceAccountBytes)
   const product = {} as Product
+  product.price_account = priceAccountKey.toBase58()
   let idx = 48
   while (idx < size) {
     const keyLength = data[idx]


### PR DESCRIPTION
Alternative to #25 and #26. At first I was hesitant to do this as opposed to including it as a `PublicKey`, but given that alternative in #25 is breaking and that the alternative in #26 is not as easy to use as this, I think it's a good option.