### PR TITLE
remove dead examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 This library reads on-chain Pyth data from [@solana/web3.js](https://www.npmjs.com/package/@solana/web3.js) and returns JavaScript-friendly objects.
 
-See our [examples repo](https://github.com/pyth-network/pyth-examples) for real-world usage examples.
-
 ## Installation
 
 ### npm


### PR DESCRIPTION
https://github.com/pyth-network/pyth-examples points to a non-existent repo -- removing it for now until we have a usable link

mentioned in https://github.com/pyth-network/pyth-client-js/issues/30 by @metasal1