### PR TITLE
Add a verbose callback with access to solana account data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.0
+- Added `onPriceChangeVerbose` callback to `PythConnection` to support getting account keys and slots on each price update.
+
 ## 2.7.2
 ### Changed
 - Added pythtest program key and cluster url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -18,11 +18,23 @@ import {
 
 const ONES = '11111111111111111111111111111111'
 
+export type AccountUpdate<T> = {
+  key: PublicKey,
+  accountInfo: AccountInfo<T>,
+  slot: number,
+}
+
 /**
  * Type of callback invoked whenever a pyth price account changes. The callback additionally
- * gets access product, which contains the metadata for this price account (e.g., that the symbol is "BTC/USD")
+ * gets `product`, which contains the metadata for this price account (e.g., that the symbol is "BTC/USD")
  */
 export type PythPriceCallback = (product: Product, price: PriceData) => void
+
+/**
+ * A price callback that additionally includes the raw solana account information. Use this if you need
+ * access to account keys and such.
+ */
+export type PythVerbosePriceCallback = (product: AccountUpdate<ProductData>, price: AccountUpdate<PriceData>) => void
 
 /**
  * Reads Pyth price data from a solana web3 connection. This class uses a callback-driven model,
@@ -33,22 +45,29 @@ export class PythConnection {
   pythProgramKey: PublicKey
   commitment: Commitment
 
-  productAccountKeyToProduct: Record<string, Product> = {}
+  productAccountKeyToProduct: Record<string, AccountUpdate<ProductData>> = {}
   priceAccountKeyToProductAccountKey: Record<string, string> = {}
 
-  callbacks: PythPriceCallback[] = []
+  callbacks: PythVerbosePriceCallback[] = []
 
-  private handleProductAccount(key: PublicKey, account: AccountInfo<Buffer>) {
-    const { priceAccountKey, type, product } = parseProductData(account.data)
-    this.productAccountKeyToProduct[key.toString()] = product
-    if (priceAccountKey.toString() !== ONES) {
-      this.priceAccountKeyToProductAccountKey[priceAccountKey.toString()] = key.toString()
+  private handleProductAccount(key: PublicKey, account: AccountInfo<Buffer>, slot: number) {
+    const productData = parseProductData(account.data)
+    this.productAccountKeyToProduct[key.toString()] = {
+      key,
+      slot,
+      accountInfo: {
+        ...account,
+        data: productData,
+      }
+    }
+    if (productData.priceAccountKey.toString() !== ONES) {
+      this.priceAccountKeyToProductAccountKey[productData.priceAccountKey.toString()] = key.toString()
     }
   }
 
   private handlePriceAccount(key: PublicKey, account: AccountInfo<Buffer>, slot: number) {
-    const product = this.productAccountKeyToProduct[this.priceAccountKeyToProductAccountKey[key.toString()]]
-    if (product === undefined) {
+    const productUpdate = this.productAccountKeyToProduct[this.priceAccountKeyToProductAccountKey[key.toString()]]
+    if (productUpdate === undefined) {
       // This shouldn't happen since we're subscribed to all of the program's accounts,
       // but let's be good defensive programmers.
       throw new Error(
@@ -57,9 +76,17 @@ export class PythConnection {
     }
 
     const priceData = parsePriceData(account.data, slot)
+    const priceUpdate = {
+      key,
+      slot,
+      accountInfo: {
+        ...account,
+        data: priceData
+      }
+    }
 
     for (const callback of this.callbacks) {
-      callback(product, priceData)
+      callback(productUpdate, priceUpdate)
     }
   }
 
@@ -72,7 +99,7 @@ export class PythConnection {
           // We can skip these because we're going to get every account owned by this program anyway.
           break
         case AccountType.Product:
-          this.handleProductAccount(key, account)
+          this.handleProductAccount(key, account, slot)
           break
         case AccountType.Price:
           if (!productOnly) {
@@ -117,7 +144,12 @@ export class PythConnection {
 
   /** Register callback to receive price updates. */
   public onPriceChange(callback: PythPriceCallback) {
-    this.callbacks.push(callback)
+    this.callbacks.push((product, price) => callback(product.accountInfo.data.product, price.accountInfo.data));
+  }
+
+  /** Register a verbose callback to receive price updates. */
+  public onPriceChangeVerbose(callback: PythVerbosePriceCallback) {
+    this.callbacks.push(callback);
   }
 
   /** Stop receiving price updates. Note that this also currently deletes all registered callbacks. */

--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -18,6 +18,7 @@ import {
 
 const ONES = '11111111111111111111111111111111'
 
+/** An update to the content of the solana account at `key` that occurred at `slot`. */
 export type AccountUpdate<T> = {
   key: PublicKey,
   accountInfo: AccountInfo<T>,

--- a/src/example_ws_usage.ts
+++ b/src/example_ws_usage.ts
@@ -3,20 +3,20 @@ import { PythConnection } from './PythConnection'
 import { getPythClusterApiUrl, getPythProgramKeyForCluster, PythCluster } from './cluster'
 import { PriceStatus } from '.'
 
-const SOLANA_CLUSTER_NAME: PythCluster = 'mainnet-beta'
+const SOLANA_CLUSTER_NAME: PythCluster = 'devnet'
 const connection = new Connection(getPythClusterApiUrl(SOLANA_CLUSTER_NAME))
 const pythPublicKey = getPythProgramKeyForCluster(SOLANA_CLUSTER_NAME)
 
 const pythConnection = new PythConnection(connection, pythPublicKey)
 pythConnection.onPriceChangeVerbose((productAccount, priceAccount) => {
-  // The arguments to the callback include solana account information if you need it.
+  // The arguments to the callback include solana account information / the update slot if you need it.
   const product = productAccount.accountInfo.data.product;
   const price = priceAccount.accountInfo.data;
   // sample output:
   // SRM/USD: $8.68725 ±$0.0131
   if (price.price && price.confidence) {
     // tslint:disable-next-line:no-console
-    console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence} (account key: ${priceAccount.key} update slot: ${priceAccount.slot})`)
+    console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence}`)
   } else {
     // tslint:disable-next-line:no-console
     console.log(`${product.symbol}: price currently unavailable. status is ${PriceStatus[price.status]}`)

--- a/src/example_ws_usage.ts
+++ b/src/example_ws_usage.ts
@@ -8,12 +8,15 @@ const connection = new Connection(getPythClusterApiUrl(SOLANA_CLUSTER_NAME))
 const pythPublicKey = getPythProgramKeyForCluster(SOLANA_CLUSTER_NAME)
 
 const pythConnection = new PythConnection(connection, pythPublicKey)
-pythConnection.onPriceChange((product, price) => {
+pythConnection.onPriceChangeVerbose((productAccount, priceAccount) => {
+  // The arguments to the callback include solana account information if you need it.
+  const product = productAccount.accountInfo.data.product;
+  const price = priceAccount.accountInfo.data;
   // sample output:
   // SRM/USD: $8.68725 ±$0.0131
   if (price.price && price.confidence) {
     // tslint:disable-next-line:no-console
-    console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence}`)
+    console.log(`${product.symbol}: $${price.price} \xB1$${price.confidence} (account key: ${priceAccount.key} update slot: ${priceAccount.slot})`)
   } else {
     // tslint:disable-next-line:no-console
     console.log(`${product.symbol}: price currently unavailable. status is ${PriceStatus[price.status]}`)


### PR DESCRIPTION
I'm trying to use this library to build a dashboard in pyth-monkey and I need access to the account keys / slots of updates. I've run into this problem before so I figured it's worth adding to the API. 

This change adds a new kind of callback to the connection API that gives you all of the associated solana metadata in addition to the content of the account. I did this via a new function / callback type in order to maintain backward compatibility.

