### PR TITLE
Expose anchor coder and change idl for consistency

### DIFF
--- a/src/__tests__/Anchor.test.ts
+++ b/src/__tests__/Anchor.test.ts
@@ -1,7 +1,7 @@
 import { AnchorProvider, Wallet } from '@coral-xyz/anchor'
 import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 import { BN } from 'bn.js'
-import { getPythProgramKeyForCluster, pythOracleProgram, PythOracleCoder } from '../index'
+import { getPythProgramKeyForCluster, pythOracleProgram, pythOracleCoder } from '../index'
 
 test('Anchor', (done) => {
   jest.setTimeout(60000)
@@ -17,7 +17,7 @@ test('Anchor', (done) => {
     .instruction()
     .then((instruction) => {
       expect(instruction.data).toStrictEqual(Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]))
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('initMapping')
       expect(decoded?.data).toStrictEqual({})
     })
@@ -27,7 +27,7 @@ test('Anchor', (done) => {
     .instruction()
     .then((instruction) => {
       expect(instruction.data).toStrictEqual(Buffer.from([2, 0, 0, 0, 1, 0, 0, 0]))
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('addMapping')
       expect(decoded?.data).toStrictEqual({})
     })
@@ -37,7 +37,7 @@ test('Anchor', (done) => {
     .instruction()
     .then((instruction) => {
       expect(instruction.data).toStrictEqual(Buffer.from([2, 0, 0, 0, 3, 0, 0, 0]))
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('updProduct')
       expect(decoded?.data).toStrictEqual({})
     })
@@ -48,7 +48,7 @@ test('Anchor', (done) => {
     .instruction()
     .then((instruction) => {
       expect(instruction.data).toStrictEqual(Buffer.from([2, 0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0]))
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('addPrice')
       expect(decoded?.data).toStrictEqual({ expo: 1, pType: 1 })
     })
@@ -64,7 +64,7 @@ test('Anchor', (done) => {
           0, 0, 5,
         ]),
       )
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('addPublisher')
       expect(decoded?.data.pub.equals(new PublicKey(5))).toBeTruthy()
     })
@@ -80,7 +80,7 @@ test('Anchor', (done) => {
           0, 0, 0, 0,
         ]),
       )
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('updPrice')
       expect(decoded?.data.status === 1).toBeTruthy()
       expect(decoded?.data.price.eq(new BN(42))).toBeTruthy()
@@ -99,7 +99,7 @@ test('Anchor', (done) => {
           0, 0, 0, 0,
         ]),
       )
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('updPriceNoFailOnError')
       expect(decoded?.data.status === 1).toBeTruthy()
       expect(decoded?.data.price.eq(new BN(42))).toBeTruthy()
@@ -118,7 +118,7 @@ test('Anchor', (done) => {
           0, 0, 0, 0,
         ]),
       )
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('aggPrice')
       expect(decoded?.data.status === 1).toBeTruthy()
       expect(decoded?.data.price.eq(new BN(42))).toBeTruthy()
@@ -132,7 +132,7 @@ test('Anchor', (done) => {
     .instruction()
     .then((instruction) => {
       expect(instruction.data).toStrictEqual(Buffer.from([2, 0, 0, 0, 12, 0, 0, 0, 5, 0, 0, 0]))
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('setMinPub')
       expect(decoded?.data.minPub === 5).toBeTruthy()
     })
@@ -155,7 +155,7 @@ test('Anchor', (done) => {
           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8,
         ]),
       )
-      const decoded = (pythOracle.coder as PythOracleCoder).instruction.decode(instruction.data)
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
       expect(decoded?.name).toBe('updPermissions')
       expect(decoded?.data.masterAuthority.equals(new PublicKey(6))).toBeTruthy()
       expect(decoded?.data.dataCurationAuthority.equals(new PublicKey(7))).toBeTruthy()

--- a/src/anchor/idl.json
+++ b/src/anchor/idl.json
@@ -56,7 +56,7 @@
           "isSigner": true
         },
         {
-          "name": "newProductAccount",
+          "name": "productAccount",
           "isMut": true,
           "isSigner": true
         }

--- a/src/anchor/program.ts
+++ b/src/anchor/program.ts
@@ -12,7 +12,12 @@ export function pythOracleProgram(programId: PublicKey, provider: AnchorProvider
   return new Program<PythOracle>(IDL as PythOracle, programId, provider, new PythOracleCoder(IDL as Idl))
 }
 
-export { PythOracleCoder } from './coder'
+export function pythOracleCoder(): PythOracleCoder {
+  return new PythOracleCoder(IDL as PythOracle);
+}
+
+export { default as pythIdl } from "./idl.json";
+
 
 export type PythOracle = {
   version: '2.20.0'
@@ -72,7 +77,7 @@ export type PythOracle = {
           isSigner: true
         },
         {
-          name: 'newProductAccount'
+          name: 'productAccount'
           isMut: true
           isSigner: true
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,4 +370,4 @@ export const parsePriceData = (data: Buffer, currentSlot?: number): PriceData =>
 export { PythConnection } from './PythConnection'
 export { PythHttpClient } from './PythHttpClient'
 export { getPythProgramKeyForCluster } from './cluster'
-export { pythOracleProgram, PythOracleCoder } from './anchor'
+export { pythOracleProgram, pythOracleCoder, pythIdl } from './anchor'


### PR DESCRIPTION
- Rename `newProductAccount` to `productAccount` in the IDL for consistency 
- Expose some components of the anchor client for reuse in other pieces of code