### PR TITLE
Use numComponents

### DIFF
--- a/src/__tests__/Price.test.ts
+++ b/src/__tests__/Price.test.ts
@@ -111,5 +111,7 @@ test('Handle price getting stale', (done) => {
   expect(stalePrice.price).toBeUndefined()
   expect(stalePrice.confidence).toBeUndefined()
 
+  expect(price.numComponentPrices).toBe(price.priceComponents.length)
+
   done()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,19 +329,14 @@ export const parsePriceData = (data: Buffer, currentSlot?: number): PriceData =>
   // price components - up to 32
   const priceComponents: PriceComponent[] = []
   let offset = 240
-  let shouldContinue = true
-  while (offset < data.length && shouldContinue) {
-    const publisher = PKorNull(data.slice(offset, offset + 32))
+  while (priceComponents.length < numComponentPrices) {
+    const publisher = new PublicKey(data.slice(offset, offset + 32))
     offset += 32
-    if (publisher) {
-      const componentAggregate = parsePriceInfo(data.slice(offset, offset + 32), exponent)
-      offset += 32
-      const latest = parsePriceInfo(data.slice(offset, offset + 32), exponent)
-      offset += 32
-      priceComponents.push({ publisher, aggregate: componentAggregate, latest })
-    } else {
-      shouldContinue = false
-    }
+    const componentAggregate = parsePriceInfo(data.slice(offset, offset + 32), exponent)
+    offset += 32
+    const latest = parsePriceInfo(data.slice(offset, offset + 32), exponent)
+    offset += 32
+    priceComponents.push({ publisher, aggregate: componentAggregate, latest })
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export interface Price {
 }
 
 export interface PriceComponent {
-  publisher: PublicKey | null
+  publisher: PublicKey
   aggregate: Price
   latest: Price
 }


### PR DESCRIPTION
The previous logic is bad because it doesn't match what actually happens on-chain and it also doesn't enforce that `price.numComponentPrices === price.priceComponents.length`