### PR TITLE
Arbitrary product metadata

### DIFF
--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -46,7 +46,7 @@ export class PythConnection {
         data: productData,
       },
     }
-    if (productData.priceAccountKey.toString() !== ONES) {
+    if (productData.priceAccountKey) {
       this.priceAccountKeyToProductAccountKey[productData.priceAccountKey.toString()] = key.toString()
     }
   }

--- a/src/__tests__/Example.test.ts
+++ b/src/__tests__/Example.test.ts
@@ -20,7 +20,7 @@ test('Mapping', (done) => {
         return
       }
       const { product, priceAccountKey } = parseProductData(accountInfo.data)
-      connection.getAccountInfo(priceAccountKey).then((accountInfo) => {
+      connection.getAccountInfo(priceAccountKey!).then((accountInfo) => {
         if (!accountInfo) {
           done('No price accountInfo')
           return

--- a/src/__tests__/Price.test.ts
+++ b/src/__tests__/Price.test.ts
@@ -23,22 +23,18 @@ test('Price', (done) => {
         connection.getAccountInfo(mapping.productAccountKeys[0]).then((accountInfo) => {
           if (accountInfo && accountInfo.data) {
             const product = parseProductData(accountInfo.data)
-            if (product.priceAccountKey) {
-              connection.getAccountInfo(product.priceAccountKey).then((accountInfo) => {
-                if (accountInfo && accountInfo.data) {
-                  const price = parsePriceData(accountInfo.data)
-                  console.log(product.product.symbol)
-                  console.log(price)
-                  expect(price.magic).toBe(Magic)
-                  expect(price.version).toBe(Version)
-                  done()
-                } else {
-                  done('No price accountInfo')
-                }
-              })
-            } else {
-              done('Product account has price account')
-            }
+            connection.getAccountInfo(product.priceAccountKey!).then((accountInfo) => {
+              if (accountInfo && accountInfo.data) {
+                const price = parsePriceData(accountInfo.data)
+                console.log(product.product.symbol)
+                console.log(price)
+                expect(price.magic).toBe(Magic)
+                expect(price.version).toBe(Version)
+                done()
+              } else {
+                done('No price accountInfo')
+              }
+            })
           } else {
             done('No product accountInfo')
           }

--- a/src/__tests__/Price.test.ts
+++ b/src/__tests__/Price.test.ts
@@ -23,18 +23,22 @@ test('Price', (done) => {
         connection.getAccountInfo(mapping.productAccountKeys[0]).then((accountInfo) => {
           if (accountInfo && accountInfo.data) {
             const product = parseProductData(accountInfo.data)
-            connection.getAccountInfo(product.priceAccountKey).then((accountInfo) => {
-              if (accountInfo && accountInfo.data) {
-                const price = parsePriceData(accountInfo.data)
-                console.log(product.product.symbol)
-                console.log(price)
-                expect(price.magic).toBe(Magic)
-                expect(price.version).toBe(Version)
-                done()
-              } else {
-                done('No price accountInfo')
-              }
-            })
+            if (product.priceAccountKey) {
+              connection.getAccountInfo(product.priceAccountKey).then((accountInfo) => {
+                if (accountInfo && accountInfo.data) {
+                  const price = parsePriceData(accountInfo.data)
+                  console.log(product.product.symbol)
+                  console.log(price)
+                  expect(price.magic).toBe(Magic)
+                  expect(price.version).toBe(Version)
+                  done()
+                } else {
+                  done('No price accountInfo')
+                }
+              })
+            } else {
+              done('Product account has price account')
+            }
           } else {
             done('No product accountInfo')
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,16 +56,11 @@ export interface MappingData extends Base {
 }
 
 export interface Product {
-  symbol: string
-  asset_type: string
-  quote_currency: string
-  tenor: string
-  price_account: string
   [index: string]: string
 }
 
 export interface ProductData extends Base {
-  priceAccountKey: PublicKey
+  priceAccountKey: PublicKey | null
   product: Product
 }
 
@@ -203,9 +198,9 @@ export const parseProductData = (data: Buffer): ProductData => {
   const size = data.readUInt32LE(12)
   // first price account in list
   const priceAccountBytes = data.slice(16, 48)
-  const priceAccountKey = new PublicKey(priceAccountBytes)
+  const priceAccountKey = PKorNull(priceAccountBytes)
   const product = {} as Product
-  product.price_account = priceAccountKey.toBase58()
+  if (priceAccountKey) product.price_account = priceAccountKey.toBase58()
   let idx = 48
   while (idx < size) {
     const keyLength = data[idx]


### PR DESCRIPTION
With the addition of equity price feeds, a lot of product metadata don't match the `Product` object.
I suggest turning Product into a generic `string-> string` dictionary.
Also the sdk should support product accounts that don't have a price account, in that case `product.price_account` should be `undefined`.