### PR TITLE
Export all items from cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.13.1
+
+- Export `PythCluster` and `getPythClusterApiUrl` globally
+
 ## 2.13.0
 
 - Add method to fetch individual prices specified by user

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/example_http_usage.ts
+++ b/src/example_http_usage.ts
@@ -1,6 +1,5 @@
 import { Connection } from '@solana/web3.js'
-import { getPythClusterApiUrl, getPythProgramKeyForCluster, PythCluster } from './cluster'
-import { PriceStatus, PythHttpClient } from '.'
+import { PriceStatus, PythHttpClient, getPythClusterApiUrl, getPythProgramKeyForCluster, PythCluster } from '.'
 
 const PYTHNET_CLUSTER_NAME: PythCluster = 'pythnet'
 const connection = new Connection(getPythClusterApiUrl(PYTHNET_CLUSTER_NAME))

--- a/src/example_ws_usage.ts
+++ b/src/example_ws_usage.ts
@@ -1,7 +1,6 @@
 import { Connection } from '@solana/web3.js'
 import { PythConnection } from './PythConnection'
-import { getPythClusterApiUrl, getPythProgramKeyForCluster, PythCluster } from './cluster'
-import { PriceStatus } from '.'
+import { getPythClusterApiUrl, getPythProgramKeyForCluster, PythCluster, PriceStatus } from '.'
 
 const PYTHNET_CLUSTER_NAME: PythCluster = 'pythnet'
 const connection = new Connection(getPythClusterApiUrl(PYTHNET_CLUSTER_NAME))

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,5 +394,5 @@ export const parsePermissionData = (data: Buffer): PermissionData => {
 
 export { PythConnection } from './PythConnection'
 export { PythHttpClient } from './PythHttpClient'
-export { getPythProgramKeyForCluster } from './cluster'
+export { getPythProgramKeyForCluster, PythCluster, getPythClusterApiUrl } from './cluster'
 export { pythOracleProgram, pythOracleCoder, pythIdl } from './anchor'


### PR DESCRIPTION
In version 2.13, if you copy the `example_ws_usage.ts` code, both `PythCluster` and `getPythClusterApiUrl` are not defined. This is because they are not exported in the `index.ts`. This request adds those exports.