### PR TITLE
AddProduct creates the Product metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -105,7 +105,12 @@ export class PythConnection {
   /** Create a PythConnection that reads its data from an underlying solana web3 connection.
    *  pythProgramKey is the public key of the Pyth program running on the chosen solana cluster.
    */
-  constructor(connection: Connection, pythProgramKey: PublicKey, commitment: Commitment = 'finalized', feedIds?: PublicKey[]) {
+  constructor(
+    connection: Connection,
+    pythProgramKey: PublicKey,
+    commitment: Commitment = 'finalized',
+    feedIds?: PublicKey[],
+  ) {
     this.connection = connection
     this.pythProgramKey = pythProgramKey
     this.commitment = commitment
@@ -124,21 +129,20 @@ export class PythConnection {
       this.handleAccount(account.pubkey, account.account, true, currentSlot)
     }
 
-    if(this.feedIds) {
+    if (this.feedIds) {
       // Filter down to only the feeds we want
       const rawIDs = this.feedIds.map((feed) => feed.toString())
       accounts = accounts.filter((feed) => rawIDs.includes(feed.pubkey.toString()))
-      for (const account of accounts){
+      for (const account of accounts) {
         this.connection.onAccountChange(
-        account.pubkey,
+          account.pubkey,
 
-        (accountInfo, context) => {
-          this.handleAccount(account.pubkey, accountInfo, false, context.slot)
-        },
-        this.commitment,
-          )
+          (accountInfo, context) => {
+            this.handleAccount(account.pubkey, accountInfo, false, context.slot)
+          },
+          this.commitment,
+        )
       }
-
     } else {
       this.connection.onProgramAccountChange(
         this.pythProgramKey,

--- a/src/__tests__/Anchor.test.ts
+++ b/src/__tests__/Anchor.test.ts
@@ -40,7 +40,11 @@ test('Anchor', (done) => {
       symbol: 'Crypto.ETH/USD',
       generic_symbol: 'ETHUSD',
     })
-    .accounts({ fundingAccount: PublicKey.unique(), productAccount: PublicKey.unique(), tailMappingAccount: PublicKey.unique() })
+    .accounts({
+      fundingAccount: PublicKey.unique(),
+      productAccount: PublicKey.unique(),
+      tailMappingAccount: PublicKey.unique(),
+    })
     .instruction()
     .then((instruction) => {
       const decoded = pythOracleCoder().instruction.decode(instruction.data)

--- a/src/__tests__/Anchor.test.ts
+++ b/src/__tests__/Anchor.test.ts
@@ -32,6 +32,28 @@ test('Anchor', (done) => {
       expect(decoded?.data).toStrictEqual({})
     })
   pythOracle.methods
+    .addProduct({
+      asset_type: 'Crypto',
+      base: 'ETH',
+      description: 'ETH/USD',
+      quote_currency: 'USD',
+      symbol: 'Crypto.ETH/USD',
+      generic_symbol: 'ETHUSD',
+    })
+    .accounts({ fundingAccount: PublicKey.unique(), productAccount: PublicKey.unique(), tailMappingAccount: PublicKey.unique() })
+    .instruction()
+    .then((instruction) => {
+      const decoded = pythOracleCoder().instruction.decode(instruction.data)
+      expect(decoded?.name).toBe('addProduct')
+      expect(decoded?.data.asset_type).toBe('Crypto')
+      expect(decoded?.data.base).toBe('ETH')
+      expect(decoded?.data.description).toBe('ETH/USD')
+      expect(decoded?.data.quote_currency).toBe('USD')
+      expect(decoded?.data.symbol).toBe('Crypto.ETH/USD')
+      expect(decoded?.data.generic_symbol).toBe('ETHUSD')
+    })
+
+  pythOracle.methods
     .updProduct({
       asset_type: 'Crypto',
       base: 'BTC',

--- a/src/anchor/coder/instructions.ts
+++ b/src/anchor/coder/instructions.ts
@@ -89,7 +89,7 @@ export class PythOracleInstructionCoder implements InstructionCoder {
       throw new Error(`Unknown method: ${methodName}`)
     }
 
-    /// updProduct has its own format
+    /// updProduct and addProduct have their own format
     if (methodName === 'updProduct' || methodName === 'addProduct') {
       let offset = 0
       for (const key of Object.keys(ix.productMetadata)) {
@@ -101,7 +101,7 @@ export class PythOracleInstructionCoder implements InstructionCoder {
       if (offset > MAX_METADATA_SIZE) {
         throw new Error('The metadata is too long')
       }
-      const data = buffer.subarray(0, MAX_METADATA_SIZE)
+      const data = buffer.subarray(0, offset)
       return Buffer.concat([discriminator, data])
     } else {
       const len = layout.encode(ix, buffer)
@@ -136,7 +136,7 @@ export class PythOracleInstructionCoder implements InstructionCoder {
       return null
     }
 
-    /// updProduct has its own format
+    /// updProduct and addProduct have their own format
     if (decoder.name === 'updProduct' || decoder.name === 'addProduct') {
       const product: Product = {}
       let idx = 0

--- a/src/anchor/idl.json
+++ b/src/anchor/idl.json
@@ -103,7 +103,14 @@
           }
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "productMetadata",
+          "type": {
+            "defined": "ProductMetadata"
+          }
+        }
+      ]
     },
     {
       "name": "updProduct",

--- a/src/anchor/program.ts
+++ b/src/anchor/program.ts
@@ -123,7 +123,14 @@ export type PythOracle = {
           }
         },
       ]
-      args: []
+      args: [
+        {
+          name: 'productMetadata'
+          type: {
+            defined: 'ProductMetadata'
+          }
+        },
+      ]
     },
     {
       name: 'updProduct'

--- a/src/example_ws_single_feed.ts
+++ b/src/example_ws_single_feed.ts
@@ -9,7 +9,7 @@ const pythPublicKey = getPythProgramKeyForCluster(PYTHNET_CLUSTER_NAME)
 // This example shows Crypto.SOL/USD
 const feeds = [new PublicKey('H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG')]
 
-const pythConnection = new PythConnection(connection, pythPublicKey, "confirmed", feeds)
+const pythConnection = new PythConnection(connection, pythPublicKey, 'confirmed', feeds)
 pythConnection.onPriceChangeVerbose((productAccount, priceAccount) => {
   // The arguments to the callback include solana account information / the update slot if you need it.
   const product = productAccount.accountInfo.data.product


### PR DESCRIPTION
Currently you have to to AddProduct and UpdProduct to set up a product, which is awkward. 
This was fixed onchain in https://github.com/pyth-network/pyth-client/pull/332
This is the corresponding js update.