### PR TITLE
Optimize rpc calls

### DIFF
--- a/src/PythConnection.ts
+++ b/src/PythConnection.ts
@@ -121,8 +121,12 @@ export class PythConnection {
    *  each time a Pyth price account is updated.
    */
   public async start() {
-    let accounts = await this.connection.getProgramAccounts(this.pythProgramKey, this.commitment)
-    const currentSlot = await this.connection.getSlot(this.commitment)
+    const accSlotProm = await Promise.all([
+      this.connection.getProgramAccounts(this.pythProgramKey, this.commitment),
+      this.connection.getSlot(this.commitment),
+    ])
+    let accounts = accSlotProm[0]
+    const currentSlot = accSlotProm[1]
     // Handle all accounts once since we need to handle product accounts
     // at least once
     for (const account of accounts) {

--- a/src/PythHttpClient.ts
+++ b/src/PythHttpClient.ts
@@ -51,12 +51,14 @@ export class PythHttpClient {
     const prices = new Array<PriceData>()
 
     // Retrieve data from blockchain
-    const accountList = await this.connection.getProgramAccounts(this.pythProgramKey, this.commitment)
+    const [accountList, currentSlot] = await Promise.all([
+      this.connection.getProgramAccounts(this.pythProgramKey, this.commitment),
+      this.connection.getSlot(this.commitment),
+    ])
 
     // Populate products and prices
     const priceDataQueue = new Array<PriceData>()
     const productAccountKeyToProduct = new Map<string, Product>()
-    const currentSlot = await this.connection.getSlot(this.commitment)
 
     // Initialize permission field as undefined
     let permissionData
@@ -121,10 +123,12 @@ export class PythHttpClient {
    */
   public async getAssetPricesFromAccounts(priceAccounts: PublicKey[]): Promise<PriceData[]> {
     const priceDatas: PriceData[] = []
-    const currentSlotPromise = this.connection.getSlot(this.commitment)
-    const accountInfos = await this.connection.getMultipleAccountsInfo(priceAccounts, this.commitment)
 
-    const currentSlot = await currentSlotPromise
+    const [accountInfos, currentSlot] = await Promise.all([
+      this.connection.getMultipleAccountsInfo(priceAccounts, this.commitment),
+      this.connection.getSlot(this.commitment),
+    ])
+
     for (let i = 0; i < priceAccounts.length; i++) {
       // Declare local variable to silence typescript warning; otherwise it thinks accountInfos[i] can be undefined
       const accInfo = accountInfos[i]


### PR DESCRIPTION
- Getting slot and program accounts was being called synchronously in many spots where it could've been called concurrently. This PR changes this. 
- Increases the response time anywhere between 500ms and 1000ms when testing locally