### PR TITLE
update anchor to 0.28.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.19.0
+
+- Upgrade `@coral-xyz/anchor` to `^0.28.1-beta.1`
+- Upgrade `@coral-xyz/borsh` to `^0.28.0`
+
 ## 2.18.0
 
 - Optimize Solana RPC calls

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.18.0",
+      "version": "2.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.28.1-beta.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.28.1-beta.1",
-        "@coral-xyz/borsh": "^0.26.0",
+        "@coral-xyz/borsh": "^0.28.0",
         "buffer": "^6.0.1"
       },
       "devDependencies": {
@@ -652,21 +652,6 @@
         "node": ">=11"
       }
     },
-    "node_modules/@coral-xyz/anchor/node_modules/@coral-xyz/borsh": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
-      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
-      "dependencies": {
-        "bn.js": "^5.1.2",
-        "buffer-layout": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.68.0"
-      }
-    },
     "node_modules/@coral-xyz/anchor/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -684,9 +669,9 @@
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/@coral-xyz/borsh": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
-      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -6277,15 +6262,6 @@
         "toml": "^3.0.0"
       },
       "dependencies": {
-        "@coral-xyz/borsh": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
-          "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
-          "requires": {
-            "bn.js": "^5.1.2",
-            "buffer-layout": "^1.2.0"
-          }
-        },
         "camelcase": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -6299,9 +6275,9 @@
       }
     },
     "@coral-xyz/borsh": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
-      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
       "requires": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,6 +652,21 @@
         "node": ">=11"
       }
     },
+    "node_modules/@coral-xyz/anchor/node_modules/@coral-xyz/borsh": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
     "node_modules/@coral-xyz/anchor/node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -669,9 +684,9 @@
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/@coral-xyz/borsh": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
-      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
+      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -6262,6 +6277,15 @@
         "toml": "^3.0.0"
       },
       "dependencies": {
+        "@coral-xyz/borsh": {
+          "version": "0.28.0",
+          "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+          "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
+          "requires": {
+            "bn.js": "^5.1.2",
+            "buffer-layout": "^1.2.0"
+          }
+        },
         "camelcase": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -6275,9 +6299,9 @@
       }
     },
     "@coral-xyz/borsh": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
-      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
+      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
       "requires": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coral-xyz/anchor": "^0.26.0",
+        "@coral-xyz/anchor": "^0.28.1-beta.1",
         "buffer": "^6.0.1"
       },
       "devDependencies": {
@@ -627,11 +627,11 @@
       "dev": true
     },
     "node_modules/@coral-xyz/anchor": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.26.0.tgz",
-      "integrity": "sha512-PxRl+wu5YyptWiR9F2MBHOLLibm87Z4IMUBPreX+DYBtPM+xggvcPi0KAN7+kIL4IrIhXI8ma5V0MCXxSN1pHg==",
+      "version": "0.28.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.28.1-beta.1.tgz",
+      "integrity": "sha512-JdKr4IQqY719wts0wzhHIffpAo4fdJ25gPLfFN75d6LMfCKvwPupyDUigaT+ac6UWTw/bDdBbJFY6QSRvlTnrA==",
       "dependencies": {
-        "@coral-xyz/borsh": "^0.26.0",
+        "@coral-xyz/borsh": "^0.28.0",
         "@solana/web3.js": "^1.68.0",
         "base64-js": "^1.5.1",
         "bn.js": "^5.1.2",
@@ -668,9 +668,9 @@
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/@coral-xyz/borsh": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
-      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -6240,11 +6240,11 @@
       "dev": true
     },
     "@coral-xyz/anchor": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.26.0.tgz",
-      "integrity": "sha512-PxRl+wu5YyptWiR9F2MBHOLLibm87Z4IMUBPreX+DYBtPM+xggvcPi0KAN7+kIL4IrIhXI8ma5V0MCXxSN1pHg==",
+      "version": "0.28.1-beta.1",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.28.1-beta.1.tgz",
+      "integrity": "sha512-JdKr4IQqY719wts0wzhHIffpAo4fdJ25gPLfFN75d6LMfCKvwPupyDUigaT+ac6UWTw/bDdBbJFY6QSRvlTnrA==",
       "requires": {
-        "@coral-xyz/borsh": "^0.26.0",
+        "@coral-xyz/borsh": "^0.28.0",
         "@solana/web3.js": "^1.68.0",
         "base64-js": "^1.5.1",
         "bn.js": "^5.1.2",
@@ -6274,9 +6274,9 @@
       }
     },
     "@coral-xyz/borsh": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
-      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.28.0.tgz",
+      "integrity": "sha512-/u1VTzw7XooK7rqeD7JLUSwOyRSesPUk0U37BV9zK0axJc1q0nRbKFGFLYCQ16OtdOJTTwGfGp11Lx9B45bRCQ==",
       "requires": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "buffer": "^6.0.1",
     "@coral-xyz/anchor": "^0.28.1-beta.1",
-    "@coral-xyz/borsh": "^0.26.0"
+    "@coral-xyz/borsh": "^0.28.0"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.30.2"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "buffer": "^6.0.1",
-    "@coral-xyz/anchor": "^0.26.0"
+    "@coral-xyz/anchor": "^0.28.1-beta.1"
   },
   "peerDependencies": {
     "@solana/web3.js": "^1.30.2"


### PR DESCRIPTION
The Anchor library on which the Pyth SDK depends on had a bug in their rollup config. They were marking assert as an external but unless you are using node.js it won't be available at runtime. This can result in a bug similar to what the Phantom guy (vaguely) described [here](https://github.com/Bonfida/sns-sdk/commit/3c901154b419102e9eb6552c8877ac1fb6ed35e8#r116106947).
