### PR TITLE
fix: use uint8 instead of int8 for instruction serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.20.0",
+  "version": "2.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/client",
-      "version": "2.20.0",
+      "version": "2.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/client",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "Client for consuming Pyth price data",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/anchor/coder/instructions.ts
+++ b/src/anchor/coder/instructions.ts
@@ -93,9 +93,9 @@ export class PythOracleInstructionCoder implements InstructionCoder {
     if (methodName === 'updProduct' || methodName === 'addProduct') {
       let offset = 0
       for (const key of Object.keys(ix.productMetadata)) {
-        offset += buffer.subarray(offset).writeInt8(key.length)
+        offset += buffer.subarray(offset).writeUInt8(key.length)
         offset += buffer.subarray(offset).write(key)
-        offset += buffer.subarray(offset).writeInt8(ix.productMetadata[key].length)
+        offset += buffer.subarray(offset).writeUInt8(ix.productMetadata[key].length)
         offset += buffer.subarray(offset).write(ix.productMetadata[key])
       }
       if (offset > MAX_METADATA_SIZE) {


### PR DESCRIPTION
We have some instructions to update product metadata that have size of more than int8 max (127) and the on-chain program reads them as u8. So we are switching to UInt8 instead.